### PR TITLE
test hooking of worker creation to inject message channels

### DIFF
--- a/sample/index.js
+++ b/sample/index.js
@@ -1,0 +1,57 @@
+var _consumer;
+var _msgChannels = {};
+
+const init = () => {
+    _consumer = new Worker("main.js");
+
+    _consumer.onmessage = (event) => {
+        const data = event.data;
+        if(data?.cmd === 'createMsgChannelPort') {
+            let msgChn = data.msgChannelPort;
+            _msgChannels[data.workerID] = msgChn;
+            msgChn.onmessage = onMsgChannelMessage;            
+        } else if(data?.cmd === 'deleteMsgChannelPort') {
+            handleDeleteMsgChannelPort(data);
+        } else if (data.source === "appthread") {
+            switch (data.type) {
+                case "asyncCall":
+                    const userData = "Huge JSON object";
+                    console.log("2. [Main UI Thread] Received message from Application Thread");
+                    console.log(`3. [Main UI Thread] Sending back '${userData}' to Application Thread`);
+                    _consumer.postMessage({
+                        source: "mainthread",
+                        eventType: "asyncCall",
+                        userData: userData
+                    });
+                    break;
+                default: {
+                    if (_onMessageCallback) {
+                        _onMessageCallback(JSON.stringify(data));
+                    } else {
+                        _msgCache.push(JSON.stringify(data));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+};
+
+function onMsgChannelMessage(event) {
+    const data = event.data;
+    if(data?.cmd === 'PING') {
+        console.log(`In the Main UI thread, got PING with payload from worker thread ${data.workerID}:"${data?.payload}"`);
+        _msgChannels[data.workerID].postMessage({
+            'cmd': 'PONG',
+            'payload': 'Hello from the Main UI'
+        });
+    } else if(data?.cmd === 'deleteMsgChannelPort') {
+        handleDeleteMsgChannelPort(data);
+    }
+};
+
+function handleDeleteMsgChannelPort(data) {
+    console.log(`Main UI: deleting msg channel for worker ${data.workerID}`)
+    _msgChannels[data.workerID].close();
+    delete _msgChannels[data.workerID];
+}

--- a/sample/library.js
+++ b/sample/library.js
@@ -1,0 +1,41 @@
+// override allocateUnusedWorker to set up the msg channels
+LibraryManager.library.$PThread.allocateUnusedWorker = function() {
+    let msgChn = new MessageChannel();
+    let pthreadMainJs = locateFile('{{{ PTHREAD_WORKER_FILE }}}');
+
+    let preWorkerJs = locateFile('pre_worker.js');
+    let worker = new Worker(preWorkerJs);
+    PThread.unusedWorkers.push(worker);
+
+    let workerID = PThread.nextWorkerID;
+    PThread.nextWorkerID++;
+
+    worker.postMessage({
+        'cmd': 'initializeWorker',
+        'msgChannelPort': msgChn.port2,
+        'scriptPath': pthreadMainJs,
+        'workerID': workerID
+    }, [msgChn.port2]);
+
+    postMessage({
+        'cmd': 'createMsgChannelPort',
+        'msgChannelPort': msgChn.port1,
+        'workerID': workerID
+    }, [msgChn.port1]);
+
+    worker.workerID = workerID;
+};
+
+LibraryManager.library.$PThread.nextWorkerID = 1;
+
+LibraryManager.library.$originalKillThread = LibraryManager.library.$killThread;
+LibraryManager.library.$killThread__deps.push('$originalKillThread');
+LibraryManager.library.$killThread = function(pthread_ptr) {
+    let worker = PThread.pthreads[pthread_ptr];
+    postMessage({
+        'cmd': "deleteMsgChannelPort",
+        'workerID': worker.workerID
+    });
+
+    return originalKillThread(pthread_ptr);
+};

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <pthread.h>
+
+void* worker_thread(void* arg)
+{
+    std::cout << "hello from the worker, run " << (int)arg << "!" << std::endl;
+
+    return nullptr;
+}
+
+int main()
+{
+    std::cout << "hello from main!" << std::endl;
+
+    for(int n = 0; n < 4; ++n)
+    {
+        pthread_t worker;
+        pthread_create(&worker, NULL, worker_thread, (void*)n);
+        pthread_join(worker, NULL);
+    }    
+
+    return 0;
+}

--- a/sample/postload.js
+++ b/sample/postload.js
@@ -1,0 +1,16 @@
+__original_emscripten_thread_exit = __emscripten_thread_exit;
+__emscripten_thread_exit = Module["__emscripten_thread_exit"] = 
+    function __emscripten_thread_exit(...args) {
+        console.log(`Exiting thread...`);
+        // the cleanup here doesn't seem necessary - the threads get returned to the pool to be reused
+        /* 
+        Module['msgChannelPort'].postMessage({
+            'cmd': "deleteMsgChannelPort",
+            'workerID': Module['workerID']
+        });
+
+        Module['msgChannelPort'].close();
+        */
+
+        return __original_emscripten_thread_exit(...args);
+    };

--- a/sample/pre_worker.js
+++ b/sample/pre_worker.js
@@ -1,0 +1,9 @@
+self.onmessage = (e) => {
+    if(e.data.cmd == 'initializeWorker') {
+        importScripts(e.data.scriptPath);
+        Module['msgChannelPort'] = e.data.msgChannelPort;
+        Module['workerID'] = e.data.workerID;
+    } else {
+        console.log('Unexpected message in pre_worker!');
+    }
+};

--- a/sample/preload.js
+++ b/sample/preload.js
@@ -1,0 +1,77 @@
+let _onAsyncCallResolve;
+
+const execAsyncCall = () => {
+    return new Promise((resolve) => {
+        _onAsyncCallResolve = resolve;
+        postMessage({
+            source: "appthread",
+            type: "asyncCall"
+        });
+    });
+}
+const onAsyncCallComplete = (userData) => {
+    _onAsyncCallResolve && _onAsyncCallResolve(userData);
+}
+
+function msgChannelOnMessage(event) {
+    const data = event.data;
+    if(data?.cmd === 'PONG') {
+        console.log(`In worker thread ${Module.workerID} (ENVIRONMENT_IS_PTHREAD = ${ENVIRONMENT_IS_PTHREAD}), got PONG with payload:"${data?.payload}"`);        
+    }
+}
+
+originalInstantiateWasm = Module?.instantiateWasm;
+Module.instantiateWasm = function (imports, successCallback) {
+    if(ENVIRONMENT_IS_PTHREAD)
+    {
+        Module.msgChannelPort.onmessage = msgChannelOnMessage;
+        Module.msgChannelPort.postMessage({
+            'cmd': 'PING',
+            'payload': 'Hello from the worker thread!',
+            'workerID': Module.workerID
+        });
+
+        // in worker thread, wasm module has already been successfully loaded (passed from main thread)
+        return originalInstantiateWasm(imports, successCallback);
+    }
+
+    asyncCall();
+
+    // browser supports instantiate Streaming
+    if (typeof WebAssembly.instantiateStreaming == "function") {
+        WebAssembly.instantiateStreaming(fetch("main.wasm"), imports)
+        .then(obj => {
+            successCallback(obj.instance, obj.module);
+        })
+        .catch(function (reason) {
+            abort(reason);
+        });
+    }
+}
+
+const asyncCall = () => {
+    addRunDependency("__asyncCall__");
+    console.log(`1. [Application Thead] ENVIRONMENT_IS_PTHREAD = ${ENVIRONMENT_IS_PTHREAD}; Making async call; Posting message to Main UI thread;`);
+    execAsyncCall().then((userData) => {
+        console.log(`4. [Application Thead] ENVIRONMENT_IS_PTHREAD = ${ENVIRONMENT_IS_PTHREAD}; Received '${userData}' from Main UI thread; ==== LOOP SUCCESS`);
+        removeRunDependency("__asyncCall__");
+    });
+}
+
+original_onmessage = onmessage;
+onmessage = (message) => {
+    const data = message.data;
+
+    switch (data.source) {
+        case "mainthread": {
+            if (data.eventType === "asyncCall") {
+                onAsyncCallComplete(data.userData);
+            }
+            break;
+        }
+        default: {
+            original_onmessage(message);
+            break;
+        }
+    } 
+}


### PR DESCRIPTION
This is one possible way to inject message channels from workers threads to the main UI thread, without any modification to emscripten code. Basically adapted https://github.com/emscripten-core/emscripten/pull/18184 so it doesn't touch base emscripten code.

The main idea is to use ```--js-library``` to override ```$PThread.allocateUnusedWorker``` with our custom function. Our custom function sets up message channel as before and posts ```port1``` to the main UI thread, then starts the new worker thread to run ```pre_worker.js```, which sets up ```Module['msgChannelPort'] = port2```. ```pre_worker.js``` in turn loads the original ```main.worker.js```, so execution proceeds as normal.

Now, the worker thread in ```main.js``` can access port2 via ```Module.msgChannelPort``` to directly send to/receive from the main UI thread.

```--post-js``` is also used, to show overriding of ```__emscripten_thread_exit```, in case any cleanup of the message channel is needed there (although not sure if that's the right place depending on the use case).

From the output, it looks likes the message channels function properly (PING and PONG between worker threads and the main UI thread).
Results:
```
1. [Application Thead] ENVIRONMENT_IS_PTHREAD = false; Making async call; Posting message to Main UI thread;
index.js:19 2. [Main UI Thread] Received message from Application Thread
index.js:20 3. [Main UI Thread] Sending back 'Huge JSON object' to Application Thread
main.js:79 4. [Application Thead] ENVIRONMENT_IS_PTHREAD = false; Received 'Huge JSON object' from Main UI thread; ==== LOOP SUCCESS
index.js:43 In the Main UI thread, got PING with payload from worker thread 1:"Hello from the worker thread!"
main.js:42 In worker thread 1 (ENVIRONMENT_IS_PTHREAD = true), got PONG with payload:"Hello from the Main UI"
index.js:43 In the Main UI thread, got PING with payload from worker thread 2:"Hello from the worker thread!"
main.js:42 In worker thread 2 (ENVIRONMENT_IS_PTHREAD = true), got PONG with payload:"Hello from the Main UI"
main.js:1758 hello from main!
main.js:1758 hello from the worker, run 0!
main.js:5808 Exiting thread...
main.js:1758 hello from the worker, run 1!
main.js:5808 Exiting thread...
main.js:1758 hello from the worker, run 2!
main.js:5808 Exiting thread...
main.js:1758 hello from the worker, run 3!
main.js:5808 Exiting thread...
```

Built with command line
```emcc main.cpp   -pthread -s PTHREAD_POOL_SIZE=2   --pre-js preload.js --post-js postload.js --js-library library.js -o main.js```